### PR TITLE
Add support for path args appearing in JSON args as well

### DIFF
--- a/unificontrol/metaprogram.py
+++ b/unificontrol/metaprogram.py
@@ -30,11 +30,13 @@ class _UnifiAPICall:
     "A representation of a single API call in a specific site"
     def __init__(self, doc, endpoint,
                  path_arg_name=None, path_arg_optional=True,
+                 path_arg_in_request_body=False,
                  json_args=None, json_body_name=None, json_fix=None,
                  rest_command=None, method=None,
                  need_login=True):
         self._endpoint = endpoint
         self._path_arg_name = path_arg_name
+        self._path_arg_in_request_body = path_arg_in_request_body
         self._json_args = json_args
         self._json_body_name = json_body_name
         self._rest = rest_command
@@ -86,6 +88,9 @@ class _UnifiAPICall:
         client = bound.arguments["self"]
         path_arg = bound.arguments[self._path_arg_name] if self._path_arg_name else None
         rest_dict = bound.arguments[self._json_body_name] if self._json_body_name else {}
+        if self._path_arg_in_request_body:
+            if self._path_arg_name:
+                rest_dict[self._path_arg_name] = bound.arguments[self._path_arg_name]
         if self._rest:
             rest_dict["cmd"] = self._rest
         if self._json_args:


### PR DESCRIPTION
Some Unifi requests (such as `rest/firewallgroup`) use the _id field as both a path parameter and part of the JSON arguments when being being updated by PUT requests.

This change adds the `path_arg_in_request_body` keyword parameter to UnifiAPICall which indicates the path_parameter should be replicated into the JSON request dict as well.

## Example Usage

I've successfully used this modification to support updating firewall groups on software based unifi controller.

```python
list_firewallgroups = UnifiAPICall(
    """List the detail of firewall groups

    Returns:
        List of dictionaries with firewall groups
    """,
    "rest/firewallgroup",
)

create_firewallgroup = UnifiAPICall(
    """Create a firewall group

    Returns:
        List of dictionaries with firewall groups
    """,
    "rest/firewallgroup",
    json_args=[
        "group_type",
        "name",
        "group_members",
    ],
    method="POST",
)

set_firewallgroup = UnifiAPICall(
    """Update an existing firewall group

    Returns:
        List of dictionaries with firewall groups
    """,
    "rest/firewallgroup",
    path_arg_name="_id",
    path_arg_optional=False,
    path_arg_in_request_body=True,
    json_args=[
        "site_id",
        "group_type",
        "name",
        "group_members",
    ],
    method="PUT",
)
```